### PR TITLE
Accessibility: do not convey meaning through colour alone

### DIFF
--- a/themes/beautifulhugo/static/css/light.css
+++ b/themes/beautifulhugo/static/css/light.css
@@ -49,9 +49,11 @@ ul {
     padding-left: 2em;
 }
 
-a, a:visited {
+a:links, a:visited {
     color: #0085a1;
-    text-decoration: none;
+    /* text-decoration: none; */
+    text-decoration: underline;
+    text-decoration-skip-ink: auto;
 }
 
 a:hover {

--- a/themes/beautifulhugo/static/css/light.css
+++ b/themes/beautifulhugo/static/css/light.css
@@ -51,7 +51,6 @@ ul {
 
 a:links, a:visited {
     color: #0085a1;
-    /* text-decoration: none; */
     text-decoration: underline;
     text-decoration-skip-ink: auto;
 }


### PR DESCRIPTION
Some people aren't sensitive to colour, so in order to differentiate links from surrounding text, we must rely on colour **plus** something else. Reinstate underlines, please pretty please.

/me doing my Bambi eyes