### PR TITLE
Template Github d'ajout de signature

### DIFF
--- a/.github/ISSUE_TEMPLATE/signature.md
+++ b/.github/ISSUE_TEMPLATE/signature.md
@@ -1,0 +1,8 @@
+---
+name: Signature
+about: Ajouter une signature
+title: 'Signature'
+labels: ''
+---
+
+[Prénom Nom](https://web-ou-reseau-social), fonction et éventuellement organisation si vous le souhaitez (pas obligatoire)


### PR DESCRIPTION
Proposition : ajout d'un template d'ISSUE Github qui permet de montrer directement le format de la signature.

À adapter : à voir si vous préférer que ça soit mis dans le corps de l'issue ou le titre