### PR TITLE
Manifeste : espaces insécables

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -75,8 +75,8 @@ l'automatisation au service du bien public plutôt qu'à celui de quelques milli
 
 En conséquence, nous appelons :
 
-* à participer au mouvement de grève et aux manifestations contre la réforme ;
-* à alimenter les [caisses de grève](https://mamot.fr/@gaspacho/103255035118067057) pour compenser la perte de revenus des grévistes ;
+* à participer au mouvement de grève et aux manifestations contre la réforme ;
+* à alimenter les [caisses de grève](https://mamot.fr/@gaspacho/103255035118067057) pour compenser la perte de revenus des grévistes ;
 * à afficher sur nos sites web et dans nos entreprises notre soutien à la lutte contre la réforme.
 
 ## Signez !


### PR DESCRIPTION
Ajoute des espaces insécables pour éviter un retour à la ligne disgracieux.

Évite ce genre de soucis avec le point-virgule :

<img width="734" alt="Capture d’écran 2019-12-13 à 11 56 53" src="https://user-images.githubusercontent.com/179923/70795266-b3b1c900-1d9f-11ea-8c50-2b7d3ebaebdb.png">
