### PR TITLE
Appel à la grève

### DIFF
--- a/content/publications/appel-a-la-greve.md
+++ b/content/publications/appel-a-la-greve.md
@@ -1,0 +1,56 @@
+---
+title: ✊ onestla.tech  
+subtitle: Appel à la grève  
+date: 2019-12-13T15:49:29+01:00  
+draft: false
+---
+
+Longtemps le gouvernement a décrédibilisé le mouvement de grève contre la réforme des retraites, 
+le jugeant absurde dans la mesure où rien n'avait été présenté. C'est maintenant chose faite. 
+Ce mouvement a forcé Edouard Philippe à dévoiler son jeu plus tôt que prévu. 
+
+Finalement, tout ce qui avait fuité dans les médias et sur les réseaux sociaux s'est réalisé :
+- la réforme concerne tout le monde, contrairement à ce que tentait de faire croire la propagande pro-gouvernementale
+- la durée de cotisation pour toucher une retraite à taux plein est poussée à 64 ans, ce qui correspond exactement 
+à l'[espérance de vie en bonne santé][esperance-de-vie] : bonne nouvelle, vous aurez du temps libre pour être malades. 
+D'autre part, 60,2% des plus de 55 ans sont en situation de [chômage à longue durée][chomage-seniors],
+à quoi bon allonger la période de travail si c'est pour rester au chômage ?
+- la valeur du point n'est pas fixée mais pourrait être inscrite dans la loi et pourra donc être modifiée au gré 
+des gouvernements
+- la réforme universelle est tellement juste et bénéfique que certains régimes (spéciaux ?) garderont un départ avant 
+l'âge légal : policiers, militaires, douaniers, pompiers... Les conditions de danger de ces métiers servaient à 
+justifier une telle exception, mais depuis Christophe Castaner a assuré à certains d'entre eux, même s'ils ne sont
+ pas exposés directement au danger, qu'ils partiraient avec les même conditions
+- la retraite tiendra compte de l'ensemble des revenus de la carrière plutôt que les 6 derniers mois 
+pour les fonctionnaires et les 25 dernières années pour les salariés du privé : il est donc impossible que les pensions 
+ne baissent pas
+- le minimum de pension de retraite est fixé à 1 000 € net par mois pour une personne ayant touché en continu un SMIC 
+durant toute sa vie. C'est peut-être une avancée pour certains mais est-ce réellement suffisant de se contenter du seuil 
+de pauvreté ? Et quand est-il de toutes les personnes qui, comme beaucoup de nos agriculteurs, n'ont même pas 
+ce niveau de revenus ?
+
+Pour faire avaler la pillule et diviser le mouvement, le gouvernement tente d'amadouer ceux qui sont nés avant 1975 
+en leur promettant qu'ils ne seront pas concernés par cette réforme. Il mise une fois de plus sur l'individualisme. 
+Sans doute s'imagine-t-il que des parents sont prêts à sauver leur retraite en la troquant contre celles 
+de leurs enfants. Êtes-vous prêt à ce sacrifice ? C'est pourtant ce qui se passera si nous ne nous mobilisons pas. 
+Contrairement à ce que le gouvernement laisse croire, il existe d'autres alternatives, d'autres financements et 
+des modèles plus vertueux que le rouleau compresseur qu'il tente de mettre en place.
+
+Trop longtemps, les acteurs du numérique opposés au gouvernement se sont tûs. Trop longtemps, ils ont été assimilés 
+à la StartUp Nation, mais l'appel OnEstLa.tech a prouvé le contraire. En quelques jours plus d'un millier de signatures 
+a été recueilli. Nous avons un rôle à jouer et notre ambition se doit d'être plus grande que ce que le Président 
+et son gourvenement destinent à notre société. La première étape reste cependant de bloquer cette réforme. 
+Le mouvement de grève en cours doit mettre un coup d'arrêt à des politiques toujours plus répressives 
+et inéquitables. Ils misent sur l'individualité, la division. Opposons-leur notre solidarité. Mobilisons-nous ! 
+Soutenons le mouvement ! Participons à la grève, aux manifestations et 
+donnez aux caisses de grève et aux caisses de solidarité pour les victimes de la répression ou trouvez [d'autres moyens][greve.cool] 
+de soutenir le mouvement.  
+
+Ensemble, pour le retrait de la réforme des retraites, rejoignons les cortèges sous la bannière OnEstLa.tech aux manifestations 
+du 17 décembre !
+
+
+[esperance-de-vie]: https://www.insee.fr/fr/statistiques/3281641?sommaire=3281778#graphique-figure1
+[chomage-seniors]: https://www.mieuxvivre-votreargent.fr/vie-pratique/2019/03/19/le-chomage-des-seniors-a-explose-depuis-10-ans/
+[soutiennnent-la-reforme]: https://www.huffingtonpost.fr/entry/qui-est-pour-la-reforme-des-retraites-ceux-qui-ne-la-subiront-pas_fr_5df25188e4b06a50a2eb9e83
+[greve.cool]: https://greve.cool/

--- a/themes/beautifulhugo/layouts/_default/single.html
+++ b/themes/beautifulhugo/layouts/_default/single.html
@@ -13,15 +13,6 @@
           </div>
         {{ end }}
 
-        {{ if $.Param "socialShare" }}
-            <hr/>
-            <section id="social-share">
-              <div class="list-inline footer-links">
-                {{ partial "share-links" . }}
-              </div>
-            </section>
-        {{ end }}
-
         {{ if .Site.Params.showRelatedPosts }}
           {{ range first 1 (where (where .Site.Pages ".Params.tags" "intersect" .Params.tags) "Permalink" "!=" .Permalink) }}
             {{ $.Scratch.Set "has_related" true }}
@@ -59,7 +50,7 @@
       {{ if (.Params.comments) | or (and (or (not (isset .Params "comments")) (eq .Params.comments nil)) (and .Site.Params.comments (ne .Type "page"))) }}
         {{ if .Site.DisqusShortname }}
           {{ if .Site.Params.delayDisqus }}
-          <div class="disqus-comments">                  
+          <div class="disqus-comments">
             <button id="show-comments" class="btn btn-default" type="button">{{ i18n "show" }} <span class="disqus-comment-count" data-disqus-url="{{ trim .Permalink "/" }}">{{ i18n "comments" }}</span></button>
             <div id="disqus_thread"></div>
 


### PR DESCRIPTION
Une base de travail pour un appel à la grève lundi. Pour le moment il faudra connaître l'url pour y accéder "/posts/appel-a-l-greve" mais par la suite, on le retrouvera dans la liste des publications