### PR TITLE
Rangement du bas de page

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -1213,6 +1213,7 @@ et se sont mis d'accord pour publier cet appel.
 Ce texte appelle les travailleuses et travailleurs du numérique à se mobiliser pour dire non à la réforme des retraites
 du gouvernement et pour proposer une alternative : réduire le temps de travail en mettant la technologie au service du
 bien commun.
+Pour en savoir plus, [écoutez ce podcast](https://soundcloud.com/podcastecho/e41-appel-des-travailleuses-et-travailleurs-du-numerique-pour-une-autre-reforme-des-retraites).
 
 ### Nous contacter
 
@@ -1221,13 +1222,12 @@ onestlatech@protonmail.com
 ### Nos incohérences
 
 * Ce texte a d'abord été travaillé sur Gitlab. Des problèmes de latence et bugs dans la publication du site nous ont contraint à opter pour Github. C'était le moyen le plus simple et le moins contraignant pour nous organiser.
-* Nous utilisons Discord pour discuter facilement faute de moyens et de temps pour installer une alternative comme [Mattermost](https://mattermost.com/)
-* Nous utilisons beaucoup [Twitter](https://twitter.com/OnEstLaTech/) mais recommandons [Mastodon](https://mastodon.social/@onestlatech).
+* Nous utilisons Discord pour discuter faute de moyens et de temps pour installer une alternative comme Mattermost.
+* Nous utilisons beaucoup Twitter mais recommandons Mastodon.
 
 ## Pour aller plus loin
 
-* [Rejoindre le Discord onestla.tech](https://discord.gg/se3PnEr) pour se coordonner et agir
-* Suivre onestla.tech [sur Twitter](https://twitter.com/OnEstLaTech) et [sur Mastodon](https://mastodon.social/@onestlatech)
-* La grève, c'est [cool](https://greve.cool)
-* Aidez votre site [à faire grève](https://github.com/thibault/strike-js)
-* [Genèse et suite à donner à cet appel #OnEstLaTech](https://soundcloud.com/podcastecho/e41-appel-des-travailleuses-et-travailleurs-du-numerique-pour-une-autre-reforme-des-retraites) (épisode de podcast)
+* Nous suivre sur [sur Twitter](https://twitter.com/OnEstLaTech) et [sur Mastodon](https://mastodon.social/@onestlatech)
+* Pour se coordonner et agir : [rejoindre notre Discord](https://discord.gg/se3PnEr) 
+* S'informer sur la grève : [La grève, c'est cool](https://greve.cool)
+* [Mettre votre site en grève](https://github.com/thibault/strike-js)


### PR DESCRIPTION
Modifs mineures : 
- éviter les répétitions (de « onestlatech »)
- les liens sont inutiles dans « nos incohérences »
- rapprocher le lien du podcast sur la genèse du paragraphe qui parle de la genèse ;)
- intitulés des liens plus explicites
- mieux libeller les actions dans « Pour aller plus loin »