### PR TITLE
improve OpenGraph tags

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -9,4 +9,4 @@ sectionPagesMenu = "main"
   socialShare = false
   organizationName = "onestla.tech"
   favicon = "avatar.png"
-  logo = "header.jpg"
+  logo = "avatar.png"

--- a/content/_index.md
+++ b/content/_index.md
@@ -3,7 +3,7 @@ title: L'appel
 date: 2019-12-09T10:44:29+01:00
 draft: false
 menu: "main"
-subtitle: L'appel
+subtitle: Appel des travailleuses et travailleurs du numérique pour une autre réforme des retraites
 navigation: L'appel 2
 weight: -40
 ---


### PR DESCRIPTION
Fix #1387 

Testé en local : pas de changements visuellement dans la page, et `og:description` et `og:image` sont bien modifiés.