### PR TITLE
Fix typos sur la signature d'Édouard Lafon

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -478,7 +478,7 @@ En conséquence, nous appelons :
 * Edmond Daoust, Développeur Web. Belge mais solidaire!
 * [Edouard Bozon](https://github.com/Edouardbozon), Développeur
 * [Edouard Cunibil](https://twitter.com/DuaelFr), [Happyculture](https://happyculture.coop)
-* Edouard Lafon ingénieur IT freelance , membre de l'[april](https://april.org) et de la de [la communauté des blue
+* Edouard Lafon ingénieur IT freelance , membre de l'[April](https://april.org) et de [la communauté des Blue Hats](https://www.modernisation.gouv.fr/le-hub-des-communautes/blue-hats)
 * [Édouard Lopez](https://twitter.com/edouard_lopez), Développeur
 * [Elie Ladias] Data Scientist, Freelance
 * [Elie Mietkiewicz](https://twitter.com/jacqueslelezard), Fullstack developer / UX designer


### PR DESCRIPTION
Correction typo suite à un signalement de la part d'Édouard en DM sur Mastodon.