### PR TITLE
Publications : ajout de l'appel au blocage

### DIFF
--- a/content/publications/appel-au-blocage.md
+++ b/content/publications/appel-au-blocage.md
@@ -1,0 +1,84 @@
+---
+title: "Travailleuses et travailleurs du numérique, bloquez et occupez vos plateformes !"
+date: 2020-01-15T15:49:29+01:00
+draft: false
+---
+
+# Travailleuses et travailleurs du numérique, bloquez et occupez vos plateformes !
+
+Nous, travailleuses et travailleurs du numérique, du développement logiciel, de la technique, de la communication numérique, freelances, membres du collectif [onestla.tech](https://onestla.tech/), personnels en lutte d’[OpenEdition](https://blogs.mediapart.fr/les-invisibles-de-lusr-2004/blog/100120/une-nouvelle-place-de-greve-retour-sur-un-blocage-numerique), _community managers_ [de Mediapart](https://blogs.mediapart.fr/community-managers-en-greve/blog/161219/community-managers-mediapart-nous-sommes-en-greve), mobilisé·es depuis le premier jour du mouvement, exigeons le retrait pur et simple du projet de réforme des retraites, symbole d’une régression et d’un niveau de violence sociale inédit.
+
+Nous nous levons également contre le mépris du dialogue social du gouvernement, que nous observons depuis plus de 40 jours, alors que tous les corps de métiers du pays sont mobilisés : cheminots, pompiers, enseignants, soignants, hospitaliers, avocats, danseurs de l’Opéra de Paris, salariés des raffineries, de l’énergie, du privé comme du public.
+
+Nous revendiquons l’exercice de piquets de grève du numérique. Pour cela, **nous appelons tous les travailleurs et travailleuses du numérique à bloquer et occuper nos réseaux sociaux et plateformes en ligne**.
+
+## 1. Travailleuses et travailleurs du numérique, la réforme nous concerne directement
+
+Les métiers du numérique, avec leur recours fréquent aux statuts de freelances, indépendants, auto-entrepreneurs, sont de plus en plus exposés aux logiques de précarisation et flexibilisation du marché du travail, qui nous éloignent de facto de nos droits de retraite. En plus d’être invisibles, nous sommes souvent isolé·es ou éparpillé·es, ce qui complique l’exercice du droit de grève.
+
+En tant que chargé·es de communication numérique ou _community managers_, nous sommes en majorité des femmes ; la réforme va nous précariser encore davantage du fait de nos carrières hachées.
+
+Nous sommes des travailleurs et travailleuses souvent jeunes, qui allons subir de plein fouet la réforme et ses dispositifs qui laissent présager un âge de départ à la retraite perpétuellement repoussé, ainsi qu’une pension réduite qui nous incitera fortement à souscrire une complémentaire auprès de fonds de pension privés, ce que nous refusons.
+
+## 2. Pourquoi il faut bloquer
+
+Comment exercer son droit de grève en 2020, à l’heure de l’individualisme galopant, de l’isolement des travailleurs et travailleuses, de la baisse d’influence voire de la défiance vis à vis des syndicats, de la remise en cause du droit de grève ? Comment rendre visible notre statut de gréviste quand on est travailleur ou travailleuse du numérique ? Comment construire un rapport de force à l’ère du calcul et de l’automatisation ?
+
+Derrière les machines, les algorithmes, les robots, les serveurs, il y a des humains. **L’automatisation et la stabilité apparente du numérique est en réalité portée à bout de bras par des travailleurs et travailleuses**, tout aussi impactés que les autres secteurs par la réforme des retraites.
+
+En tant que travailleurs invisibles, la cessation de travail ne suffit pas. Il nous faut rendre notre grève visible. Le blocage et l’occupation sont parmi les seuls moyens dont nous disposons pour faire exister notre grève et  lui donner du sens. Et cela rend à nouveau visible à nos utilisateurs et utilisatrices le travail effectué chaque jour derrière les plateformes numériques.
+
+## 3. Des actions de blocage en cours
+
+Nous avons déjà réalisé plusieurs actions de blocage numérique.
+
+Les personnels de l’unité de service et de recherche OpenEdition ont voté en AG le blocage de l’accès à leurs plus de 3000 sites d’éditeurs, revues, blogs et événements scientifiques pendant 24 heures le 17 décembre 2019. Les _community managers_ de Mediapart ont occupé leurs réseaux sociaux le 17 décembre et 9 janvier, et répètent leur action le 15 et 16 janvier. De nombreux sites ont affiché des bannières proposées par les membres du collectif onestla.tech. Partout, des initiatives fleurissent pour faire du numérique une nouvelle « Place de grève ».
+
+Ces actions nous ont appris à donner corps à notre grève. En tant que développeuses et développeurs, administratrices et administrateurs système, webmasters, chargé·es de communication ou chef·fes de projets, nous avons le droit, la légitimité et la capacité de cesser le travail, de bloquer nos outils de production, et de les utiliser pour afficher notre statut de gréviste ou notre soutien au mouvement.
+
+Nous appelons à élargir le mouvement, et à le faire savoir, en utilisant nos outils de travail : les sites, les réseaux sociaux, les services en ligne, les logiciels et applications que nous créons, éditons, gérons, animons, surveillons quotidiennement.
+
+## 4. Plusieurs façons de bloquer
+
+Plusieurs formes de blocage sont possibles :
+
+- **Le blocage d’accès.** Cela consiste à bloquer l’accès à un service sur un temps donné qui paraisse acceptable en renvoyant sur un texte de grève, pour bien différencier l’action d’une maintenance. C’est ce qu’ont fait [les personnels d’OpenEdition](https://blogs.mediapart.fr/les-invisibles-de-lusr-2004/blog/100120/une-nouvelle-place-de-greve-retour-sur-un-blocage-numerique) le 17 décembre (6 millions de visiteurs uniques mensuels) sur 24h, et ce qui est discuté chez [les membres onestla.tech](https://onestla.tech/) sur des temps plus courts.
+- **L’occupation éditoriale.** Cela consiste à remplacer le contenu habituel par celui des grévistes, qui choisissent eux mêmes la « mise en scène » des contenus. C’est ce qui a été réalisé par [les community managers de Mediapart](https://blogs.mediapart.fr/community-managers-en-greve/blog/161219/community-managers-mediapart-nous-sommes-en-greve), qui ont remplacé les posts normalement dédiés aux articles du journal par un message de grève. L’accès classique aux articles a aussi été maintenu pour ne pas léser l’employeur. [OpenEdition](https://blogs.mediapart.fr/les-invisibles-de-lusr-2004/blog/100120/une-nouvelle-place-de-greve-retour-sur-un-blocage-numerique), qui accueille des contenus issus de la recherche en sciences humaines et sociales dont certains portent sur la grève, la précarité, les retraites ou la justice sociale, a opté pour une mise en valeur de ces contenus.
+- **L’affichage d’un message.** Cela consiste, sans bloquer l’usage du site, à afficher le statut de gréviste des personnels sur le site, par exemple par une bannière ou un pop-up. Plusieurs sites ont réalisé cette mise en avant (comme le site de l’administration [demarches-simplifiees.fr](https://www.demarches-simplifiees.fr/)). Le collectif onestla.tech propose [plusieurs bannières prêtes à l’emploi](https://onestla.tech/page/ressources/).
+
+
+## 5. Comment bloquer sans se mettre en danger ?
+
+Faire grève ou décider d’une action de blocage, c’est s’exposer financièrement mais aussi socialement. Cela demande du courage, pour affirmer son engagement, mais aussi du soutien de son entourage, de ses collègues et des travailleurs et travailleuses en lutte. Cela nous conforte dans l’idée que nous devons agir ensemble, nous parler, nous rassembler. En nous organisant collectivement sur notre lieu de travail (par exemple en adhérant à un syndicat, en rejoignant le collectif onestla.tech, en développant les liens de solidarité avec nos collègues), nous pouvons nous défendre et nous protéger.
+
+_« Le nombre, l’organisation et la cohésion des employés permet d’être unis face à l’employeur, qui peut ainsi laisser couler et ne donner ni sanction ni assignation en justice. »_
+
+Voici plusieurs pistes possibles pour mener nos actions :
+
+- **Solliciter ses collègues ou collaborateurs.** Les autres membres du personnel, qui gèrent les mêmes services, sont susceptibles de remplacer les grévistes, par le simple fait de disposer des mots de passe, par exemple. Pour éviter ce risque, il est important d’obtenir leur soutien. Cela doit néanmoins rester le plus circonscrit possible pour garder la maîtrise des outils de travail, sans chercher l’accord de tout le personnel de l’entreprise.
+- **Associer son équipe.** Même sans l’accord de l’employeur, il est possible de porter collectivement la responsabilité d’un blocage, et ainsi réduire les risques d’éventuelles sanctions. C’est ce qu’ont fait les personnels d’OpenEdition en votant le blocage en AG. La solidarité la plus large possible entre travailleurs et travailleuses du numérique permet de faire front contre les menaces ou intimidations de la hiérarchie.
+- **Associer son employeur.** Selon le secteur d’activité, notamment dans le privé, nous ne sommes pas en lutte contre notre employeur mais contre une réforme gouvernementale demandée et soutenue par le patronat. Pour éviter les sanctions, il est possible de chercher l’approbation voire le soutien de son employeur, en rappelant que l’objectif n’est pas de léser le service ni le chiffre d’affaire de l’entreprise mais bien de faire valoir son droit de grève. C’est ce qui a été fait par les _community managers_ de Mediapart.
+
+## 6. Pour une action de blocage collective, rejoignez-nous !
+
+Nous appelons à nous rejoindre tout de suite pour réfléchir à de nouvelles actions. Organisons-nous, soutenons-nous pour réaliser collectivement des actions que nous ne pourrions pas réaliser seuls. Notre souhait : être suffisamment nombreux pour **organiser une prochaine opération collective de blocage**. Contactez-nous, rejoignez-nous !
+
+- Venez discuter sur le [Discord onestla.tech](https://discordapp.com/invite/se3PnEr)
+- Rejoignez le groupe Facebook des [Community Managers en grève](https://www.facebook.com/groups/2494931734082277/)
+
+## Ressources
+
+**Articles**
+
+* [Appel des travailleuses et travailleurs du numérique pour une autre réforme des retraites](https://onestla.tech/) (onestla.tech)
+* [Community managers à Mediapart, nous sommes en grève!](https://blogs.mediapart.fr/community-managers-en-greve/blog/161219/community-managers-mediapart-nous-sommes-en-greve) (Mediapart)
+* [Les personnels d’OpenEdition en lutte contre la réforme des retraites](https://academia.hypotheses.org/7104) (OpenEdition)
+* [Une nouvelle place de Grève? - Retour sur un blocage numérique](https://blogs.mediapart.fr/les-invisibles-de-lusr-2004/blog/100120/une-nouvelle-place-de-greve-retour-sur-un-blocage-numerique) (OpenEdition)
+* [Community managers en grève: un point d’étape](https://blogs.mediapart.fr/community-managers-en-greve/blog/030120/community-managers-en-greve-un-point-detape) (Mediapart)
+* [Le droit de grève à l’ère du numérique](https://blogs.mediapart.fr/community-managers-en-greve/blog/150120/le-droit-de-greve-l-ere-du-numerique) (Mediapart)
+* [Comment désobéir ?](https://www.hacking-social.com/2019/12/03/comment-desobeir-quelques-listes/)  (Hacking social)
+
+**Moyens d’actions**
+
+* [Pancartes, bannières, tracts](https://onestla.tech/page/ressources/) (onestla.tech)
+* [Widget pour bloquer son site web](https://github.com/noelmace/widget-engreve)


### PR DESCRIPTION
Ajout de l'appel au blocage conjoint des community Managers de Mediapart, des personnels d'OpenEdition et de onestla.tech.

Ce texte a été écrit à plusieurs mains, et élaboré sur le Discord de onestla.tech.

Il va également être publié sur Le Club de Mediapart – dans l'idée de pouvoir en discuter pendant le Live de Mediapart ce soir à 18h, qui abordera le sujet.