### PR TITLE
Corrige l'affichage du logo d'en-tête sur les pages /publications/

### DIFF
--- a/themes/beautifulhugo/layouts/partials/header.html
+++ b/themes/beautifulhugo/layouts/partials/header.html
@@ -3,7 +3,7 @@
     <header class="header-section">
         <div class="intro-header no-img">
             <div class="{{ .Type }}-heading{{ if .IsHome }} home-heading{{ end }}">
-                <h1 class="heading-title"><img src="PoingLeve.png" alt="" aria-hidden="true" />on<span class="bold">est</span>la.tech<span class="bold">/</span></h1>
+                <h1 class="heading-title"><img src="/PoingLeve.png" alt="" aria-hidden="true" />on<span class="bold">est</span>la.tech<span class="bold">/</span></h1>
             </div>
         </div>
     </header>


### PR DESCRIPTION
Le logo de onestla.tech ne s'affichait pas dans les pages d'un sous-dossier (comme `/publications/`).

<img width="804" alt="Capture d’écran 2020-01-16 à 11 01 13" src="https://user-images.githubusercontent.com/179923/72515042-93b66f00-384f-11ea-8cb1-e49f49a1ba4f.png">
