### PR TITLE
Appel à l'action le 24 janvier

### DIFF
--- a/content/publications/appel-action-24-janvier.md
+++ b/content/publications/appel-action-24-janvier.md
@@ -1,0 +1,42 @@
+---
+title: "Appel au blocage numérique le vendredi 24 janvier"
+date: 2020-01-20T21:49:29+01:00
+draft: false
+---
+
+La grève contre le projet de la réforme des retraites dure depuis bientôt 50 jours. Vendredi 24 janvier, prochaine journée de mobilisation, de nombreuses actions sont prévues. Pour nous aussi, travailleuses et travailleurs du numérique, notre grève doit être visible.
+
+À la suite de [notre appel précédent](https://onestla.tech/publications/appel-au-blocage/), nous appelons à **bloquer et occuper nos plateformes collectivement le vendredi 24 janvier**. Pendant 24 heures, ensemble, bloquons et occupons l’accès aux sites web, aux systèmes automatiques et aux réseaux sociaux que nous gérons. De nombreuses actions de blocage ou occupation numérique ont déjà eu lieu, cette fois-ci, agissons ensemble ! Montrons que nous sommes toujours présents, déterminés, nombreux, et solidaires.
+
+## Différentes formes de blocage
+
+Comme nous l’écrivions précédemment, [plusieurs formes de blocages](https://onestla.tech/publications/appel-au-blocage/#4-plusieurs-faons-de-bloquer) sont possibles :
+
+- Le blocage d’accès (total ou partiel) ;
+- L’occupation éditoriale ;
+- L’affichage d’un message (non-bloquant).
+
+## Une action collective pour construire le rapport de force
+
+En réalisant ces actions de façon collective, nous revendiquons le blocage comme un exercice du droit de grève pour les travailleurs du numérique, et nous limitons les risques de sanction qui pourraient intervenir en agissant de façon isolée. Dans beaucoup de professions, utiliser son outil de travail pendant une grève pour un blocage, l’organisation de piquets de grève, sont des pratiques syndicales courantes. L’état du [droit concernant les grèves numériques](https://blogs.mediapart.fr/community-managers-en-greve/blog/150120/le-droit-de-greve-l-ere-du-numerique) est encore flou, mais ce flou peut nous être favorable.
+
+C’est le rapport de force et l’action collective qui nous protègeront le mieux des sanctions. Regroupé dans une même action, nous pouvons plus facilement la revendiquer comme un mouvement d’ensemble.
+
+Par ailleurs, en cas de menace ou sanction d’un employeur suite à cette action, tous les participant·es s’engagent collectivement à dénoncer les tentatives de pression de cet employeur.
+
+## Comment faire ?
+
+1. **Discutez-en avec vos collègues.**
+
+    Nous conseillons d’agir à plusieurs, avec le soutien de collègues de votre équipe ou la légitimité d’une assemblée générale.
+
+    Pour un rappel des fondamentaux de la grève, vous pouvez consulter [greve.cool](https://greve.cool).
+2. **Préparez le blocage ou l’occupation.**
+
+    Pour un site : vous pouvez programmer le blocage à l’avance avec le [widget de grève](https://github.com/onestlatech/widget-engreve) prêt à l'emploi.
+
+    Pour les réseaux sociaux : vous pouvez programmer vos tweets et posts sur Facebook.
+3. **Indiquez votre participation à l’action collective du 24 janvier [sur ce formulaire](https://framaforms.org/onestlatech-appel-au-blocage-numerique-contre-le-projet-de-reforme-des-retraites-le-vendredi-24)** : cela permet de communiquer à l’avance sur le nombre d’actions attendues.
+
+    Si possible, annoncez aussi votre intention de bloquer sur les réseaux sociaux, en mentionnant #blocage24janvier ou @onestlatech.
+4. **Vendredi 24 janvier, mettez en place le blocage ou l’occupation.**

--- a/content/publications/appel-action-24-janvier.md
+++ b/content/publications/appel-action-24-janvier.md
@@ -18,7 +18,7 @@ Comme nous l’écrivions précédemment, [plusieurs formes de blocages](https:/
 
 ## Une action collective pour construire le rapport de force
 
-En réalisant ces actions de façon collective, nous revendiquons le blocage comme un exercice du droit de grève pour les travailleurs du numérique, et nous limitons les risques de sanction qui pourraient intervenir en agissant de façon isolée. Dans beaucoup de professions, utiliser son outil de travail pendant une grève pour un blocage, l’organisation de piquets de grève, sont des pratiques syndicales courantes. L’état du [droit concernant les grèves numériques](https://blogs.mediapart.fr/community-managers-en-greve/blog/150120/le-droit-de-greve-l-ere-du-numerique) est encore flou, mais ce flou peut nous être favorable.
+En réalisant ces actions de façon collective, nous revendiquons le blocage comme un exercice du droit de grève pour les travailleuses et travailleurs du numérique, et nous limitons les risques de sanction qui pourraient intervenir en agissant de façon isolée. Dans beaucoup de professions, utiliser son outil de travail pendant une grève pour un blocage, l’organisation de piquets de grève, sont des pratiques syndicales courantes. L’état du [droit concernant les grèves numériques](https://blogs.mediapart.fr/community-managers-en-greve/blog/150120/le-droit-de-greve-l-ere-du-numerique) est encore flou, mais ce flou peut nous être favorable.
 
 C’est le rapport de force et l’action collective qui nous protègeront le mieux des sanctions. Regroupé dans une même action, nous pouvons plus facilement la revendiquer comme un mouvement d’ensemble.
 

--- a/content/publications/appel-action-24-janvier.md
+++ b/content/publications/appel-action-24-janvier.md
@@ -6,7 +6,7 @@ draft: false
 
 La grève contre le projet de la réforme des retraites dure depuis bientôt 50 jours. Vendredi 24 janvier, prochaine journée de mobilisation, de nombreuses actions sont prévues. Pour nous aussi, travailleuses et travailleurs du numérique, notre grève doit être visible.
 
-À la suite de [notre appel précédent](https://onestla.tech/publications/appel-au-blocage/), nous appelons à **bloquer et occuper nos plateformes collectivement le vendredi 24 janvier**. Pendant 24 heures, ensemble, bloquons et occupons l’accès aux sites web, aux systèmes automatiques et aux réseaux sociaux que nous gérons. De nombreuses actions de blocage ou occupation numérique ont déjà eu lieu, cette fois-ci, agissons ensemble ! Montrons que nous sommes toujours présents, déterminés, nombreux, et solidaires.
+À la suite de [notre appel précédent](https://onestla.tech/publications/appel-au-blocage/), nous appelons à **bloquer et occuper nos plateformes collectivement le vendredi 24 janvier**. Pendant 24 heures, ensemble, bloquons et occupons l’accès aux sites web, aux systèmes automatiques et aux réseaux sociaux que nous gérons. De nombreuses actions de blocage et d'occupation numérique ont déjà eu lieu, cette fois-ci, agissons ensemble ! Montrons que nous sommes toujours présents, déterminés, nombreux, et solidaires.
 
 ## Différentes formes de blocage
 

--- a/content/publications/appel-action-24-janvier.md
+++ b/content/publications/appel-action-24-janvier.md
@@ -22,7 +22,7 @@ En réalisant ces actions de façon collective, nous revendiquons le blocage com
 
 C’est le rapport de force et l’action collective qui nous protègeront le mieux des sanctions. Regroupé dans une même action, nous pouvons plus facilement la revendiquer comme un mouvement d’ensemble.
 
-Par ailleurs, en cas de menace ou sanction d’un employeur suite à cette action, tous les participant·es s’engagent collectivement à dénoncer les tentatives de pression de cet employeur.
+Par ailleurs, en cas de menace ou sanction d’un employeur suite à cette action, tous les participantes et participants s’engagent collectivement à dénoncer les tentatives de pression de cet employeur.
 
 ## Comment faire ?
 

--- a/themes/beautifulhugo/static/css/light.css
+++ b/themes/beautifulhugo/static/css/light.css
@@ -46,7 +46,7 @@ h2 { font-size: 2.8em; }
 h3 { font-size: 2em; }
 h4 { font-size: 1.8em; }
 p, li {
-    font-size: 1.8em;
+    font-size: 1.8rem;
     line-height: 1.6;
 }
 a {


### PR DESCRIPTION
Cette PR rajoute une publication appelant à une action concertée des travailleuses et travailleurs du numérique le vendredi 24 janvier.

Cette publication fait suite à l'appel au blocage, en proposant une date précise. La proposition est d'appeler les gens de la tech à bloquer ou occuper leurs plateformes en concertation le même jour.

**À faire avant de merger**

- [x] Relecture
- [x] Ajouter le lien vers le framaform indiquant le blocage