### PR TITLE
Corrige l'affichage du titre quand on utilise un lien intérieur

### DIFF
--- a/themes/beautifulhugo/static/css/light.css
+++ b/themes/beautifulhugo/static/css/light.css
@@ -188,6 +188,14 @@ code {
     top: 20em;
 }
 
+/* Fix the header appearing under the sticky nav-bar when using a #anchor link */
+.blog-post h2 {
+    padding-top: 80px;
+}
+.blog-post * + h2 {
+    margin-top: -60px;
+}
+
 .social-networks {
     font-size: 1.8em;
     font-weight: bold;


### PR DESCRIPTION
Quand on clique sur un lien qui référence une section particulière d'une publication (a#anchor), le titre est masqué sous la barre de navigation flottante.

Cette PR fait en sorte que le titre soit visible, même quand on y accède avec un lien intérieur.

## Exemple de lien

https://onestla.tech/publications/appel-au-blocage/#2-pourquoi-il-faut-bloquer

## Avant

<img width="853" alt="Capture d’écran 2020-01-20 à 22 17 01" src="https://user-images.githubusercontent.com/179923/72758280-9d82fe00-3bd2-11ea-9706-11e1b2e99a7c.png">

## Après

<img width="827" alt="Capture d’écran 2020-01-20 à 22 17 12" src="https://user-images.githubusercontent.com/179923/72758286-a1168500-3bd2-11ea-8cca-9cfe018eeaa3.png">
